### PR TITLE
feat: bump axios to 1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
       "elliptic": "6.6.1",
       "secp256k1": "4.0.4",
       "cross-spawn": "7.0.5",
-      "axios": "1.13.5",
+      "axios": "1.15.0",
       "@babel/runtime-corejs3": "7.26.10",
       "@babel/runtime": "7.26.10",
       "@babel/helpers": "7.26.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ overrides:
   elliptic: 6.6.1
   secp256k1: 4.0.4
   cross-spawn: 7.0.5
-  axios: 1.13.5
+  axios: 1.15.0
   '@babel/runtime-corejs3': 7.26.10
   '@babel/runtime': 7.26.10
   '@babel/helpers': 7.26.10
@@ -2890,12 +2890,12 @@ packages:
       possible-typed-array-names: 1.1.0
     dev: false
 
-  /axios/1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+  /axios/1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.4
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -5345,8 +5345,9 @@ packages:
       sisteransi: 1.0.5
     dev: true
 
-  /proxy-from-env/1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  /proxy-from-env/2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
     dev: false
 
   /punycode/2.3.1:
@@ -5848,7 +5849,7 @@ packages:
     resolution: {integrity: sha512-9i2N+cTkRY7Y1B/V0+ZVwCYZFhdFDalh8sbI8Tpj5O65hMURvjFnaP1u/dTwVnVw07d9M143/19KarxeAzK6pg==}
     dependencies:
       '@babel/runtime': 7.26.10
-      axios: 1.13.5
+      axios: 1.15.0
       bignumber.js: 9.1.2
       ethereum-cryptography: 2.2.1
       ethers: 6.13.5


### PR DESCRIPTION
1. npm audit fix - override axios to 1.15.0 for SSRF vulnerability